### PR TITLE
Add Gym wrapper and PPO training script with Ray Tune and wandb

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,15 @@ The system utilizes ROS framework using Python3 and was tested on Ubuntu 18.04.
 source devel/setup.bash
 rosrun smit_sim train_dqnagent.py
 ```
+
+## Training a PPO Agent with RLlib
+A lightweight Gym environment wrapping the existing `LinearPath` system is available in `scripts/smit_sim_env.py`.
+The script `scripts/train_ppo.py` demonstrates how to train a PPO agent using Ray RLlib, Ray Tune and Weights & Biases.
+
+Install the Python dependencies and launch training:
+```
+pip install -r requirements.txt
+python scripts/train_ppo.py
+```
+
+The training run will be logged to the `smit-sim` project on [Weights & Biases](https://wandb.ai/).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+ray[rllib]
+gymnasium
+wandb

--- a/scripts/smit_sim_env.py
+++ b/scripts/smit_sim_env.py
@@ -1,0 +1,59 @@
+import numpy as np
+try:
+    import gymnasium as gym
+    from gymnasium import spaces
+except ImportError:  # Fall back to the classic Gym if Gymnasium is unavailable.
+    import gym
+    from gym import spaces
+
+from smit_linear_path.linear_path import LinearPath
+
+class SmitSimEnv(gym.Env):
+    """Gym wrapper around the existing LinearPath system."""
+
+    metadata = {"render.modes": ["human"]}
+
+    def __init__(self, start=(0.0, 0.0), goal=(1.0, 1.0), dt=0.1, max_speed=1.0):
+        super().__init__()
+        self.start = np.array(start, dtype=np.float32)
+        self.goal = np.array(goal, dtype=np.float32)
+        self.dt = float(dt)
+        self.max_speed = float(max_speed)
+
+        # Actions correspond to forward speed in the range [0, max_speed].
+        self.action_space = spaces.Box(
+            low=np.array([0.0], dtype=np.float32),
+            high=np.array([self.max_speed], dtype=np.float32),
+            dtype=np.float32,
+        )
+
+        # Observations are the current 2D position of the agent.
+        self.observation_space = spaces.Box(
+            low=-np.inf, high=np.inf, shape=(2,), dtype=np.float32
+        )
+
+        self.path = LinearPath(self.start, [self.goal])
+
+    def reset(self):
+        """Reset the underlying path and return the starting observation."""
+        self.path = LinearPath(self.start, [self.goal])
+        return self._get_obs()
+
+    def step(self, action):
+        speed = float(np.clip(action[0], 0.0, self.max_speed))
+        pos, _ = self.path.step(speed, self.dt)
+        obs = pos.astype(np.float32)
+        done = self.path.get_distance() == 0
+        reward = -np.linalg.norm(self.goal - pos)
+        info = {"distance_left": self.path.get_distance()}
+        return obs, reward, done, info
+
+    def _get_obs(self):
+        return self.path.pos.astype(np.float32)
+
+    def render(self, mode="human"):
+        if mode == "human":
+            print(
+                f"pos={self.path.pos}, goal={self.goal}, remaining={self.path.get_distance()}"
+            )
+        return None

--- a/scripts/train_ppo.py
+++ b/scripts/train_ppo.py
@@ -1,0 +1,33 @@
+import ray
+from ray import tune
+from ray.rllib.algorithms.ppo import PPOConfig
+from ray.tune.registry import register_env
+from ray.tune.integration.wandb import WandbLoggerCallback
+
+from smit_sim_env import SmitSimEnv
+
+
+def env_creator(env_config):
+    return SmitSimEnv()
+
+
+if __name__ == "__main__":
+    ray.init()
+    register_env("smit_sim", env_creator)
+
+    config = (
+        PPOConfig()
+        .environment(env="smit_sim")
+        .framework("torch")
+        .rollouts(num_rollout_workers=1)
+        .training(model={"fcnet_hiddens": [64, 64]})
+    )
+
+    tune.run(
+        "PPO",
+        config=config.to_dict(),
+        stop={"training_iteration": 10},
+        callbacks=[
+            WandbLoggerCallback(project="smit-sim", log_config=True),
+        ],
+    )


### PR DESCRIPTION
## Summary
- Add SmitSimEnv Gym wrapper around the existing LinearPath system
- Provide Ray RLlib PPO training script with Ray Tune and Weights & Biases logging
- Document PPO workflow and add Python requirements

## Testing
- `python -m py_compile scripts/smit_sim_env.py scripts/train_ppo.py`
- `python - <<'PY'
import sys
sys.path.append('scripts')
import smit_sim_env
env = smit_sim_env.SmitSimEnv()
print('reset', env.reset())
print('step', env.step([0.5]))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b7fbc2abd88325aa4f6cc0564dc1b7